### PR TITLE
Enable Arm builds only for Python >= 3.9

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -20,6 +20,9 @@ jobs:
       osx_64_python3.9.____cpython:
         CONFIG: osx_64_python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
+      osx_arm64_python3.9.____cpython:
+        CONFIG: osx_arm64_python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -1,0 +1,21 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+channel_sources:
+- conda-forge/label/rust_dev,conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- arm64-apple-darwin20.0.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- osx-arm64
+zip_keys:
+- - python
+  - python_impl

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @kastman
+* @kastman @leofang

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -53,6 +53,10 @@ source run_conda_forge_build_setup
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
+
 conda $BUILD_CMD ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
 ( startgroup "Validating outputs" ) 2> /dev/null
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyobjc-core-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.9.____cpython" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>osx_arm64_python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=903&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyobjc-core-feedstock?branchName=master&jobName=osx&configuration=osx_arm64_python3.9.____cpython" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>
@@ -156,4 +163,5 @@ Feedstock Maintainers
 =====================
 
 * [@kastman](https://github.com/kastman/)
+* [@leofang](https://github.com/leofang/)
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 About pyobjc-core
 =================
 
-Home: http://pyobjc.sourceforge.net/
+Home: https://github.com/ronaldoussoren/pyobjc
 
 Package license: MIT
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pyobjc-core-feedstock/blob/master/LICENSE.txt)
 
 Summary: Python<->ObjC Interoperability Module
+
+Documentation: https://pyobjc.readthedocs.io/en/latest/
 
 Current build status
 ====================

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,6 @@
 conda_forge_output_validation: true
 bot:
   automerge: true
+build_platform:
+  osx_arm64: osx_64
+test_on_native_only: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,11 +12,14 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
-  skip: true  # [not osx or py2k or python_impl == 'pypy']
+  number: 1
+  skip: true  # [not osx or py2k or python_impl == 'pypy' or (arm64 and py < 39)]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
+  build:
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
   host:
     - python
     - pip
@@ -39,3 +42,4 @@ about:
 extra:
   recipe-maintainers:
     - kastman
+    - leofang

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,11 +33,12 @@ test:
     - objc
 
 about:
-  home: http://pyobjc.sourceforge.net/
+  home: https://github.com/ronaldoussoren/pyobjc
   license: MIT
   summary: Python<->ObjC Interoperability Module
   license_family: MIT
   license_file: License.txt
+  doc_url: https://pyobjc.readthedocs.io/en/latest/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
This PR supersedes #34. Given the discussion (https://github.com/ronaldoussoren/pyobjc/issues/355#issuecomment-894628740) I think we should build for M1 only on Python >= 3.9.

I also added myself as a maintainer.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
